### PR TITLE
Initial work to setup app deployment manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# outputs:
+*output*
+
+# local env file:
+*.env
+vars.yml

--- a/.openshift/README.md
+++ b/.openshift/README.md
@@ -1,0 +1,16 @@
+### Run on OpenShift
+Use the OpenShift manifests to build and deploy the app.
+```shell
+cd .openshift
+# Step 1: env setup
+# update the maintenance.env file to match your setup
+cp maintenance.env.sample maintenance.env
+# switch to the namespace for deployment
+oc project <namespace>
+
+# Step 2: Deploy MongoDB
+oc process --ignore-unknown-parameters=true -f mongodb-manifest.yaml --param-file=maintenance.env | oc apply -f -
+
+# Step 3: Deploy RC app
+oc process --ignore-unknown-parameters=true -f rocketchat-manifest.yaml --param-file=maintenance.env | oc apply -f -
+```

--- a/.openshift/maintenance.env.sample
+++ b/.openshift/maintenance.env.sample
@@ -1,0 +1,20 @@
+#----- RocketChat Settings -----
+APPLICATION_NAME=rocketchat-maintenance
+HOSTNAME_HTTPS=rocketchat-maintenance.pathfinder.gov.bc.ca 
+ROCKETCHAT_IMAGE_TAG=3.0
+FILE_UPLOAD_STORAGE_SIZE=5Gi
+ROCKETCHAT_REPLICAS=3
+ROCKETCHAT_MIN_HPA=1
+ROCKETCHAT_MAX_HPA=3
+MEMORY_REQUEST=1Gi
+MEMORY_LIMIT=2Gi
+CPU_REQUEST=250m
+CPU_LIMIT=500m
+VOLUME_CAPACITY=1Gi
+SC_MONGO=netapp-block-standard
+SC_FILE_UPLOAD=netapp-file-standard
+
+
+#----- mongodb settings -----
+MONGODB_SERVICE_NAME=mongodb-maintenance
+MONGODB_SECRET_NAME=mongodb-maintenance

--- a/.openshift/mongodb-manifest.yaml
+++ b/.openshift/mongodb-manifest.yaml
@@ -1,0 +1,255 @@
+Kind: Template
+apiVersion: v1
+metadata:
+  name: rocket-chat-mongodb
+  annotations:
+    description: "MongoDB database running as replicate set"
+    iconClass: "icon-nodejs"
+    tags: "nodejs,mongodb,replication,instant-app"
+
+parameters:
+  - name: MEMORY_REQUEST
+    description: Amount of Memory to Request.
+    displayName: Memory Request
+    required: true
+
+  - name: MEMORY_LIMIT
+    description: Amount of Memory to Limit.
+    displayName: Memory Limit
+    required: true
+
+  - name: CPU_REQUEST
+    description: Amount of CPU to Request.
+    displayName: Memory Request
+    required: true
+
+  - name: CPU_LIMIT
+    description: Amount of CPU to Limit.
+    displayName: Memory Limit
+    required: true
+    
+  - name: MONGODB_SERVICE_NAME
+    description: Name of the MongoDB Service
+    displayName: MongoDB Service Name
+    value: "mongodb"
+    required: true
+
+  - name: MONGODB_REPLICAS
+    description: Number of MongoDB replica pods
+    displayName: MongoDB Replicas
+    value: "3"
+    required: true
+
+  - name: MONGODB_SECRET_NAME
+    displayName: MongoDB Secret.
+    description: Name of the Secret containing MongoDB Assets
+    value: "mongodb"
+    required: true
+    
+  - name: MONGODB_USER
+    displayName: "MongoDB Connection Username"
+    description: "Username for MongoDB user that will be used for accessing the database."
+    generate: expression
+    from: "[a-zA-Z0-9]{5}"
+    required: true
+
+  - name: MONGODB_PASSWORD
+    displayName: "MongoDB Connection Password"
+    description: "Password for the MongoDB connection user."
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"
+    required: true
+
+  - name: MONGODB_DATABASE
+    displayName: "MongoDB Database Name"
+    description: "Name of the MongoDB database accessed."
+    value: rocketdb
+    required: true
+
+  - name: MONGODB_ADMIN_PASSWORD
+    displayName: "MongoDB Admin Password"
+    description: "Password for the database admin user."
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"
+    required: true
+
+  - name: MONGODB_REPLICA_NAME
+    displayName: "Replica Set Name"
+    description: "The name of the replica set."
+    value: rs0
+    required: true
+
+  - name: MONGODB_KEYFILE_VALUE
+    displayName: "Keyfile Content"
+    description: "The value of the MongoDB keyfile (https://docs.mongodb.com/manual/core/security-internal-authentication/#internal-auth-keyfile)."
+    generate: expression
+    from: "[a-zA-Z0-9]{255}"
+    required: true
+
+  - name: MONGODB_IMAGE
+    displayName: "MongoDB Docker Image"
+    description: "A reference to a supported MongoDB Docker image."
+    value: "docker-registry.default.svc:5000/openshift/mongodb"
+    required: true
+
+  - name: MONGODB_IMAGE_TAG
+    description: Name of the MongoDB tag that should be used
+    displayName: MongoDB Tag
+    value: "3.6"
+    required: true
+
+  - name: VOLUME_CAPACITY
+    displayName: "Volume Capacity for MongoDB"
+    description: "Volume space available for data, e.g. 512Mi, 2Gi."
+    required: true
+
+  - name: SC_MONGO
+    description: The Storage Class for the MongoDB
+    displayName: Storage Class for MongoDB
+    required: true
+
+objects:
+# Secrets for mongo DB 
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${MONGODB_SECRET_NAME}
+      labels:
+        app: ${APPLICATION_NAME}
+        name: "${MONGODB_SERVICE_NAME}"
+    stringData:
+      username: "${MONGODB_USER}"
+      password: "${MONGODB_PASSWORD}"
+      admin-username: "admin"
+      admin-password: "${MONGODB_ADMIN_PASSWORD}"
+      database: "${MONGODB_DATABASE}"
+      replica-name: "${MONGODB_REPLICA_NAME}"
+      mongo-url: "mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@${MONGODB_SERVICE_NAME}:27017/${MONGODB_DATABASE}?replicaSet=${MONGODB_REPLICA_NAME}"
+      mongo-oplog-url: "mongodb://admin:${MONGODB_ADMIN_PASSWORD}@${MONGODB_SERVICE_NAME}:27017/local?authSource=admin&replicaSet=${MONGODB_REPLICA_NAME}"
+
+  # A non-headless service which takes pod readiness into consideration
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: "${MONGODB_SERVICE_NAME}"
+      labels:
+        name: "${MONGODB_SERVICE_NAME}"
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+        - name: mongodb
+          port: 27017
+      selector:
+        name: "${MONGODB_SERVICE_NAME}"
+
+  # A headless service to create DNS records
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: "${MONGODB_SERVICE_NAME}-internal"
+      labels:
+        name: "${MONGODB_SERVICE_NAME}"
+        app: ${APPLICATION_NAME}
+      annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    spec:    
+      clusterIP: None
+      ports:
+        - name: mongodb
+          port: 27017
+      selector:
+        name: "${MONGODB_SERVICE_NAME}"
+
+  # Mongo DB StatefulSet
+  - kind: StatefulSet
+    apiVersion: apps/v1beta1
+    metadata:
+      name: "${MONGODB_SERVICE_NAME}"
+    spec:
+      serviceName: "${MONGODB_SERVICE_NAME}-internal"
+      replicas: "${MONGODB_REPLICAS}"
+      template:
+        metadata:
+          labels:
+            name: "${MONGODB_SERVICE_NAME}"
+            app: ${APPLICATION_NAME}
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: name
+                    operator: In
+                    values: 
+                    - ${MONGODB_SERVICE_NAME}
+                topologyKey: "kubernetes.io/hostname"
+          containers:
+            - name: mongo-container
+              image: "${MONGODB_IMAGE}:${MONGODB_IMAGE_TAG}"
+              ports:
+                - containerPort: 27017
+              args:
+                - "run-mongod-replication"
+              volumeMounts:
+                - name: mongo-data
+                  mountPath: "/var/lib/mongodb/data"
+              env:
+                - name: MONGODB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      key: username
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGODB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGODB_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      key: database
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGODB_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: admin-password
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGO_OPLOG_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: mongo-oplog-url
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGODB_REPLICA_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      key: replica-name
+                      name: "${MONGODB_SECRET_NAME}"
+                - name: MONGODB_KEYFILE_VALUE
+                  value: "${MONGODB_KEYFILE_VALUE}"
+                - name: MONGODB_SERVICE_NAME
+                  value: "${MONGODB_SERVICE_NAME}-internal"
+              resources:
+                limits:
+                  memory: "${MEMORY_LIMIT}"
+                  cpu: "${CPU_LIMIT}"
+                requests:
+                  memory: "${MEMORY_REQUEST}"
+                  cpu: "${CPU_REQUEST}"
+              readinessProbe:
+                exec:
+                  command:
+                    - stat
+                    - /tmp/initialized
+      volumeClaimTemplates:
+        - metadata:
+            name: mongo-data
+            labels:
+              app: ${APPLICATION_NAME}
+              name: "${MONGODB_SERVICE_NAME}"
+          spec:
+            accessModes: [ ReadWriteOnce ]
+            storageClassName: "${SC_MONGO}"
+            resources:
+              requests:
+                storage: "${VOLUME_CAPACITY}"

--- a/.openshift/rocketchat-manifest.yaml
+++ b/.openshift/rocketchat-manifest.yaml
@@ -1,0 +1,300 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: rocket-chat
+  annotations:
+    description: "Rocket.Chat Deployment"
+    iconClass: "icon-nodejs"
+    tags: "nodejs,mongodb,replication,instant-app"
+
+parameters:
+  - name: APPLICATION_NAME
+    description: The name assigned to the application
+    displayName: Application Name
+    required: true
+    value: rocketchat-maintenance
+
+  - name: ROCKETCHAT_IMAGE
+    description: Location of the RocketChat Image
+    displayName: RocketChat Image
+    value: registry.hub.docker.com/library/rocket.chat
+    required: true
+
+  # specify the version
+  - name: ROCKETCHAT_IMAGE_TAG
+    description: Name of the RocketChat tag that should be used
+    displayName: RocketChat Tag
+    value: "3.0"
+    required: true
+
+  - name: FILE_UPLOAD_STORAGE_SIZE
+    description: The size of storage to allocate for file uploads to RocketChat
+    displayName: File Upload Storage Size
+    required: true
+
+  # specify the storage class
+  - name: SC_FILE_UPLOAD
+    description: The Storage Class for the RocketChat uploads volume
+    displayName: File Uploads Storage Class 
+    required: true
+
+  - name: HOSTNAME_HTTPS
+    description: Hostname serving the application
+    displayName: Route Name
+    required: true
+
+  - name: ROCKETCHAT_ADMIN_PASSWORD
+    displayName: "RocketChat Admin Password"
+    description: "Password for the RocketChat admin user."
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"
+    required: true
+
+  - name: ROCKETCHAT_REPLICAS
+    description: Number of RocketChat replica pods
+    displayName: RocketChat Replicas
+    required: true
+
+  - name: ROCKETCHAT_MIN_HPA
+    description: Min Number of RocketChat pods for HPA
+    displayName: RocketChat Min HPA
+    required: true
+
+  - name: ROCKETCHAT_MAX_HPA
+    description: Max Number of RocketChat pods for HPA
+    displayName: RocketChat Max HPA
+    required: true
+  
+  - name: MEMORY_REQUEST
+    description: Amount of Memory to Request.
+    displayName: Memory Request
+    required: true
+
+  - name: MEMORY_LIMIT
+    description: Amount of Memory to Limit.
+    displayName: Memory Limit
+    required: true
+
+  - name: CPU_REQUEST
+    description: Amount of CPU to Request.
+    displayName: Memory Request
+    required: true
+
+  - name: CPU_LIMIT
+    description: Amount of CPU to Limit.
+    displayName: Memory Limit
+    required: true
+
+  - name: MONGODB_SECRET_NAME
+    displayName: MongoDB Secret.
+    description: Name of the Secret containing MongoDB Assets
+    value: "mongodb"
+    required: true
+
+objects:
+  # Create a local istag for RC from docker
+  - apiVersion: image.openshift.io/v1
+    kind: ImageStream
+    metadata:
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}
+    spec:
+      lookupPolicy:
+        local: false
+      tags:
+      - annotations: null
+        from:
+          kind: DockerImage
+          name: ${ROCKETCHAT_IMAGE}:${ROCKETCHAT_IMAGE_TAG}
+        importPolicy: {}
+        name: "${ROCKETCHAT_IMAGE_TAG}"
+        referencePolicy:
+          type: Source
+
+  # Secret for admin user credential
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-admin-secret
+    data:
+      ADMIN_USERNAME: "admin"
+      ADMIN_PASS: "${ROCKETCHAT_ADMIN_PASSWORD}"
+
+  # TODO: add a configmap for initial setup
+
+  # Service for the Rocketchat NodeJS service
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: 3000-tcp
+        port: 3000
+        protocol: TCP
+        targetPort: 3000
+      selector:
+        app: ${APPLICATION_NAME}
+        deploymentConfig: ${APPLICATION_NAME}
+      type: ClusterIP
+      SessionAffinity: None
+  
+  # Route to expose service
+  - apiVersion: v1
+    kind: Route
+    metadata:
+      name: ${APPLICATION_NAME}
+      annotations:
+        description: Route for application's http service.
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      host: "${HOSTNAME_HTTPS}"
+      port:
+        targetPort: 3000-tcp
+      to:
+        kind: Service 
+        name: ${APPLICATION_NAME}
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+
+  # PVC for app assets upload
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      annotations:
+        description: PVC for application assets upload.
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-uploads
+    spec:
+      storageClassName: ${SC_FILE_UPLOAD}
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: ${FILE_UPLOAD_STORAGE_SIZE}
+      volumename: ${APPLICATION_NAME}-uploads
+
+  # App
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ConfigChange
+      replicas: "${ROCKETCHAT_REPLICAS}"
+      selector:
+        app: "${APPLICATION_NAME}"
+        deploymentConfig: "${APPLICATION_NAME}"
+      template:
+        metadata:
+          labels:
+            app: "${APPLICATION_NAME}"
+            deploymentConfig: "${APPLICATION_NAME}"
+        spec:
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values: 
+                    - ${APPLICATION_NAME}
+                topologyKey: "kubernetes.io/hostname"
+          volumes:
+            - name: ${APPLICATION_NAME}-uploads
+              persistentVolumeClaim:
+                claimName: ${APPLICATION_NAME}-uploads
+          containers:
+          - image: ${APPLICATION_NAME}:${ROCKETCHAT_IMAGE_TAG}
+            name: ${APPLICATION_NAME}
+            env:
+            - name: MONGO_URL
+              valueFrom:
+                secretKeyRef:
+                  key: mongo-url
+                  name: "${MONGODB_SECRET_NAME}"
+            - name: MONGO_OPLOG_URL
+              valueFrom:
+                secretKeyRef:
+                  key: mongo-oplog-url
+                  name: "${MONGODB_SECRET_NAME}"
+            envFrom: 
+              - secretRef:
+                  name: ${APPLICATION_NAME}-admin-secret
+            volumeMounts:
+              - name: ${APPLICATION_NAME}-uploads
+                mountPath: /app/uploads
+            ports:
+            - containerPort: 3000
+              protocol: TCP
+            terminationMessagePath: /dev/termination-log
+            livenessProbe:
+              httpGet:
+                path: /api/info
+                port: 3000
+                scheme: HTTP
+              initialDelaySeconds: 60
+              timeoutSeconds: 5
+              periodSeconds: 20
+              successThreshold: 1
+              failureThreshold: 3
+            readinessProbe:
+              httpGet:
+                path: /api/info
+                port: 3000
+                scheme: HTTP
+              initialDelaySeconds: 120
+              timeoutSeconds: 5
+              periodSeconds: 20
+              successThreshold: 1
+              failureThreshold: 3
+            resources:
+              limits:
+                cpu: "${CPU_LIMIT}"
+                memory: "${MEMORY_LIMIT}"
+              requests:
+                memory: "${MEMORY_REQUEST}"
+                cpu: "${CPU_REQUEST}"
+          restartPolicy: Always
+      triggers:
+      - type: ConfigChange
+      - imageChangeParams:
+          automatic: true
+          from:
+            kind: ImageStreamTag
+            name: ${APPLICATION_NAME}:${ROCKETCHAT_IMAGE_TAG}
+          containerNames:
+          - ${APPLICATION_NAME}
+        type: ImageChange
+
+  # Application HA
+  - apiVersion: autoscaling/v1
+    kind: HorizontalPodAutoscaler
+    metadata:
+      labels:
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-hpa
+    spec:
+      scaleTargetRef:
+        kind: DeploymentConfig 
+        name: ${APPLICATION_NAME}
+        apiVersion: apps.openshift.io/v1
+        subresource: scale
+      minReplicas: ${ROCKETCHAT_MIN_HPA}
+      maxReplicas: ${ROCKETCHAT_MAX_HPA}
+      cpuUtilization:
+        targetCPUUtilizationPercentage: 80

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+error_on_undefined_vars = False

--- a/ansible/deployment.yml
+++ b/ansible/deployment.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  gather_facts: no
+  connection: local
+  vars_files: 
+   - vars.yml
+  vars:
+    LABEL: "app={{ APPLICATION_NAME }}"
+  tasks:
+    - name: sample get objects
+      include_tasks: tasks/get_object.yml
+
+    - name: sample create objects
+      include_tasks: tasks/create_object.yml

--- a/ansible/sample-vars.yml
+++ b/ansible/sample-vars.yml
@@ -1,0 +1,20 @@
+#----- RocketChat Settings -----
+NAMESPACE: 
+APPLICATION_NAME: rocketchat-maintenance
+HOSTNAME_HTTPS: rocketchat-maintenance.pathfinder.gov.bc.ca 
+ROCKETCHAT_IMAGE_TAG: 3.0
+FILE_UPLOAD_STORAGE_SIZE: 5Gi
+ROCKETCHAT_REPLICAS: 3
+ROCKETCHAT_MIN_HPA: 1
+ROCKETCHAT_MAX_HPA: 3
+MEMORY_REQUEST: 1Gi
+MEMORY_LIMIT: 2Gi
+CPU_REQUEST: 250m
+CPU_LIMIT: 500m
+VOLUME_CAPACITY: 1Gi
+SC_MONGO: netapp-block-standard
+SC_FILE_UPLOAD: netapp-file-standard
+
+#----- mongodb settings -----
+MONGODB_SERVICE_NAME: mongodb-maintenance
+MONGODB_SECRET_NAME: mongodb-maintenance

--- a/ansible/tasks/create_object.yml
+++ b/ansible/tasks/create_object.yml
@@ -1,0 +1,6 @@
+---
+# Create Objects:
+- name: Create objects from deployment template
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/rocketchat-manifest.yml') }}"

--- a/ansible/tasks/get_object.yml
+++ b/ansible/tasks/get_object.yml
@@ -1,0 +1,8 @@
+---
+# Get list of Objects in a namespace:
+- name: Get object by type
+  set_fact:
+    deployments: "{{ lookup('k8s', kind='dc', namespace=NAMESPACE, label_selector=LABEL) }}"
+    statefulsets: "{{ lookup('k8s', kind='StatefulSet', namespace=NAMESPACE, label_selector=LABEL) }}"
+
+- debug: msg="{{ deployments }}"

--- a/ansible/tasks/templates/rocketchat-manifest.yml
+++ b/ansible/tasks/templates/rocketchat-manifest.yml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: "{{ APPLICATION_NAME }}"
+    name: "{{ APPLICATION_NAME }}"
+    namespace: "{{ NAMESPACE }}"
+  spec:
+    ports:
+    - name: 3000-tcp
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      app: "{{ APPLICATION_NAME }}"
+      deploymentConfig: "{{ APPLICATION_NAME }}"
+    type: ClusterIP
+    SessionAffinity: None
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: "{{ APPLICATION_NAME }}"
+    namespace: "{{ NAMESPACE }}"
+    annotations:
+      description: Route for application's http service.
+    labels:
+      app: "{{ APPLICATION_NAME }}"
+  spec:
+    host: "{{ HOSTNAME_HTTPS }}"
+    port:
+      targetPort: 3000-tcp
+    to:
+      kind: Service 
+      name: "{{ APPLICATION_NAME }}"
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Initialize the OpenShift deployment config templates for RocketChat application and MongoDB:
- openshift deployment manifests: yaml template files and steps to create the app on a namespace
- start a sample ansible playbook to automate the process of deployment
